### PR TITLE
YASL args and warning reduction

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,22 +13,22 @@ interpreter/VM.o:
 	$(CC) interpreter/VM.c -c -o interpreter/VM.o
 
 interpreter/builtins/builtins.o:
-	$(CC) interpreter/builtins/builtins.c -c -o interpreter/builtins/builtins.o
+	$(CC) interpreter/builtins/builtins.c $(CFLAGS) -c -o interpreter/builtins/builtins.o
 
 interpreter/constant/constant.o:
-	$(CC) interpreter/constant/constant.c -c -o interpreter/constant/constant.o
+	$(CC) interpreter/constant/constant.c $(CFLAGS) -c -o interpreter/constant/constant.o
 
 interpreter/hashtable/hashtable.o:
-	$(CC) interpreter/hashtable/hashtable.c -c -o interpreter/hashtable/hashtable.o
+	$(CC) interpreter/hashtable/hashtable.c $(CFLAGS) -c -o interpreter/hashtable/hashtable.o
 
 interpreter/list/list.o:
-	$(CC) interpreter/list/list.c -c -o interpreter/list/list.o
+	$(CC) interpreter/list/list.c $(CFLAGS) -c -o interpreter/list/list.o
 
 interpreter/prime/prime.o:
-	$(CC) interpreter/prime/prime.c -c -o interpreter/prime/prime.o
+	$(CC) interpreter/prime/prime.c $(CFLAGS) -c -o interpreter/prime/prime.o
 
 interpreter/string8/string8.o:
-	$(CC) interpreter/string8/string8.c -c -o interpreter/string8/string8.o
+	$(CC) interpreter/string8/string8.c $(CFLAGS) -c -o interpreter/string8/string8.o
 
 interpreter/vtable/vtable.o:
-	$(CC) interpreter/vtable/vtable.c -c -o interpreter/vtable/vtable.o
+	$(CC) interpreter/vtable/vtable.c $(CFLAGS) -c -o interpreter/vtable/vtable.o

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ OUT=YASL
 OBJECTS=interpreter/VM.o interpreter/builtins/builtins.o interpreter/constant/constant.o interpreter/hashtable/hashtable.o interpreter/list/list.o interpreter/prime/prime.o interpreter/string8/string8.o interpreter/vtable/vtable.o
 
 YASL: $(OBJECTS)
-	$(CC) interpreter/main.c $(OBJECTS) $(CFLAGS) -o $(OUT)
+	$(CC) $(OBJECTS) interpreter/main.c $(CFLAGS) -o $(OUT)
 
 clean:
 	rm $(OUT) $(OBJECTS)

--- a/compiler/main.py
+++ b/compiler/main.py
@@ -1,7 +1,6 @@
 from .lexer import Lexer
 from .parser import Parser
 from .compiler import Compiler
-from .resolver import Resolver
 import sys
 from .opcode import HALT
 
@@ -17,7 +16,7 @@ def main():
         lexer = Lexer(text)
         parser = Parser(lexer.lex())
         statements = parser.parse() # = Interpreter(parser)
-        resolver = Resolver(compiler)
+        #resolver = Resolver(compiler)
         #resolver.resolve(statements)
         result = compiler.compile(statements)
         #print([hex(r) for r in result])

--- a/interpreter/builtins/builtins.c
+++ b/interpreter/builtins/builtins.c
@@ -499,10 +499,6 @@ int yasl_values(VM* vm) {
     return 0;
 }
 
-/* const Handler builtins[] = {
-    yasl_print, yasl_insert,    yasl_find,  yasl_keys,  yasl_values,    yasl_append,
-}; */
-
 VTable_t* float64_builtins() {
     VTable_t* vt = new_vtable();
     vt_insert(vt, 0x0B, (int64_t)&yasl_toint64);

--- a/interpreter/hashtable/hashtable.c
+++ b/interpreter/hashtable/hashtable.c
@@ -1,9 +1,12 @@
-#include <stdlib.h>
-#include <string.h>
-#include <math.h>
 #include "hashtable.h"
 #include "../constant/constant.h"
 #include "../prime/prime.h"
+
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+#include <stdio.h>
+
 #define HT_BASESIZE 60
 
 static int hash_function(const Constant s, const int a, const int m) {

--- a/interpreter/hashtable/hashtable.h
+++ b/interpreter/hashtable/hashtable.h
@@ -19,6 +19,7 @@ typedef struct {
     Item_t** items;
 } Hash_t;
 
+Hash_t* new_hash();
 void ht_insert(Hash_t* hashtable, Constant key, Constant value);
 Constant* ht_search(Hash_t* hashtable, Constant key);
 void ht_delete(Hash_t* hashtable, Constant key);

--- a/interpreter/main.c
+++ b/interpreter/main.c
@@ -497,8 +497,23 @@ FILE *file_ptr;
 long file_len;
 int64_t entry_point, num_globals;
 
-int main(void) {
-    file_ptr = fopen("source.yb", "rb");
+int main(int argc, char** argv) {
+    if (argc > 2) {
+        printf("ERROR: Too many arguments passed.\nUsage is: YASL [path/to/byte-code.yb]\nDefault path is \"source.yb\"\n");
+		return -1;
+    } else if (argc == 2) {
+        file_ptr = fopen(argv[1], "rb");
+		if(file_ptr == NULL) {
+			printf("ERROR: Could not open source file \"%s\".\n", argv[1]);
+			return -2;
+		}
+    } else {
+        file_ptr = fopen("source.yb", "rb");
+		if(file_ptr == NULL) {
+			printf("ERROR: Could not default open source file \"source.yb\".\n");
+			return -3;
+		}
+    }
     fseek(file_ptr, 0, SEEK_END);
     file_len = ftell(file_ptr);
     rewind(file_ptr);

--- a/interpreter/string8/string8.c
+++ b/interpreter/string8/string8.c
@@ -1,4 +1,5 @@
 #include "string8.h"
+
 //#define STRLEN(s)
 String_t* new_sized_string8(const int64_t base_size) {
     String_t* str = malloc(sizeof(String_t));

--- a/interpreter/string8/string8.c
+++ b/interpreter/string8/string8.c
@@ -1,4 +1,5 @@
 #include "string8.h"
+#include <string.h>
 
 //#define STRLEN(s)
 String_t* new_sized_string8(const int64_t base_size) {

--- a/interpreter/vtable/vtable.c
+++ b/interpreter/vtable/vtable.c
@@ -1,8 +1,11 @@
-#include <stdlib.h>
-#include <string.h>
-#include <math.h>
 #include "vtable.h"
 #include "../prime/prime.h"
+
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+#include <math.h>
+
 #define VT_BASESIZE 60
 
 static VItem_t VTOMBSTONE = {-1, 0};

--- a/interpreter/vtable/vtable.h
+++ b/interpreter/vtable/vtable.h
@@ -19,6 +19,8 @@ struct VTable_s {
 typedef struct VTable_s VTable_t;
 
 VTable_t* new_vtable(void);
+void del_vtable(VTable_t* vtable);
+
 void vt_insert(VTable_t* vtable, int64_t key, int64_t value);
 int64_t vt_search(VTable_t* vtable, int64_t key);
 void vt_delete(VTable_t* vtable, int64_t key);


### PR DESCRIPTION
Implemented the ability to optionally pass a source path to the YASL interpreter (default still "source.yb") and greatly reduced the warnings generated compiling the Interpreter (only one in my env.)